### PR TITLE
update: my.cnf でのキー名と, set global 時の変数名が異なる場合の設定方法を追加.

### DIFF
--- a/molecule/mysql_variables/group_vars/all/00-defaults.yml
+++ b/molecule/mysql_variables/group_vars/all/00-defaults.yml
@@ -1,0 +1,1 @@
+../../../../defaults/main.yml

--- a/molecule/mysql_variables/group_vars/all/99-molecule.yml
+++ b/molecule/mysql_variables/group_vars/all/99-molecule.yml
@@ -1,0 +1,7 @@
+pxc_root_password: "ansible_ci&root"
+pxc_is_clustered: no
+pxc_general_settings: 
+  slow_query_log: "ON"
+  slow_query_log_file:
+    variable: "slow_query_log_file"
+    value: "/var/log/mysql/mysql-slow.log"

--- a/molecule/mysql_variables/molecule.yml
+++ b/molecule/mysql_variables/molecule.yml
@@ -1,0 +1,10 @@
+---
+platforms:
+  - name: ${MOLECULE_DISTRO}-${ANSIBLE_VER}
+    source:
+      alias: ubuntu/${MOLECULE_DISTRO}/amd64
+
+provisioner:
+  inventory:
+    links:
+      group_vars: ${MOLECULE_SCENARIO_DIRECTORY}/group_vars

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -91,8 +91,8 @@
     login_password: "{{ pxc_root_password }}"
     login_unix_socket: "{{ pxc_socket }}"
     login_host: "localhost"
-    variable: "{{ item.key }}"
-    value: "{{ item.value }}"
+    variable: "{{ item.value.variable | default(item.key) }}"
+    value: "{{ item.value.value | default(item.value) }}"
   loop: "{{ __pxc_combined_general_settings | dict2items }}"
 
 - name: Create mysql users

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -84,6 +84,22 @@
   when:
     - inventory_hostname == pxc_db_control_node
 
+## SET GLOBAL 可能なシステム変数を適用するタスク
+#  以下のように pxc_general_settings の定義方法1と2の両方に対応するような書き方となっている
+#
+#  pxc_general_settings:
+#    max_allowed_packet: "41943040"  # 定義方法1
+#    default_time_zone:              # 定義方法2
+#      variable: "time_zone"
+#      value: "UTC"
+#
+#  このような書き方をする理由は, 例えばタイムゾーンを設定するためには, 
+#
+#    * my.cnf では 「default_time_zone = UTC」 と書く
+#    * SET GLOBAL クエリを使う場合は「SET GLOBAL time_zone = UTC;」を実行する
+#
+#  という風に変数名が違う.
+#  これらの事例に対応するために, 定義方法1と2の両方を実装している.
 - name: Update mysql pxc_general_settings (not required to restart)
   mysql_variables:
     connect_timeout: 600

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -28,7 +28,7 @@
 
 ## general_settings
 {% for item in (__pxc_combined_general_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{{ key }} = {{ value }}
+{{ key }} = {{ value.value | default(value) }}
 {% endfor %}
 
 


### PR DESCRIPTION
@ledyba-z 

pxc のタイムゾーンの変更のためにこのような機能追加をしました.
確認してもらえると助かります.

### 変更点

変数 `pxc_general_settings` に対して, my.cnf でのキー名と, set global 時の変数名が異なる場合の設定方法を追加

```yaml
pxc_general_settings: 
  max_allowed_packet: "41943040"  # こちらはいつもの定義方法
  default_time_zone:              # 新しい定義方法
    variable: "time_zone"
    value: "UTC"
```

新しい定義方法の使い所としては, 主に「my.cnf の変数名」と 「SET GLOBAL 時の変数名」が異なる時である.

上記の例では以下の 「my.cnf の作成」 と 「SET GLOBAL クエリの実行」が行われる.

```
### my.cnf 
max_allowed_packet = 41943040
default_time_zone = UTC

### SET GLOBAL クエリ
mysql> SET GLOBAL max_allowed_packet = 41943040;
mysql> SET GLOBAL time_zone = UTC;
```

一般化すると以下のようになる
```yaml
pxc_general_settings:
  key_1: "value_1"
  key_2:
    variable: "set_key_2"
    value: "value_2"
```

### 参考
* [MySQL Server Time Zone Support](https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html)