### PR TITLE
タイムゾーンを設定したい場合の前準備などをするタスクを追加

### DIFF
--- a/molecule/mysql_timezone/group_vars/all/00-defaults.yml
+++ b/molecule/mysql_timezone/group_vars/all/00-defaults.yml
@@ -1,0 +1,1 @@
+../../../../defaults/main.yml

--- a/molecule/mysql_timezone/group_vars/all/99-molecule.yml
+++ b/molecule/mysql_timezone/group_vars/all/99-molecule.yml
@@ -1,0 +1,6 @@
+pxc_root_password: "ansible_ci&root"
+pxc_is_clustered: no
+pxc_general_settings:
+  default_time_zone: 
+    variable: "time_zone"
+    value: "UTC"

--- a/molecule/mysql_timezone/molecule.yml
+++ b/molecule/mysql_timezone/molecule.yml
@@ -1,0 +1,10 @@
+---
+platforms:
+  - name: ${MOLECULE_DISTRO}-${ANSIBLE_VER}
+    source:
+      alias: ubuntu/${MOLECULE_DISTRO}/amd64
+
+provisioner:
+  inventory:
+    links:
+      group_vars: ${MOLECULE_SCENARIO_DIRECTORY}/group_vars

--- a/molecule/mysql_variables/group_vars/all/99-molecule.yml
+++ b/molecule/mysql_variables/group_vars/all/99-molecule.yml
@@ -1,4 +1,4 @@
-pxc_root_password: "ansible_ci&root"
+pxc_root_password: "ansible_ci root"  ## パスワードに半角スペースを入れた場合もついでにテスト
 pxc_is_clustered: no
 pxc_general_settings: 
   slow_query_log: "ON"

--- a/tasks/add_timezone_table.yml
+++ b/tasks/add_timezone_table.yml
@@ -1,0 +1,27 @@
+---
+# MySQL のタイムゾーンを設定するためのテーブルをインポートするタスク
+# 参考: https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html
+
+## timezone テーブルがインポートされているかどうかのチェック
+- name: Check installed timezone table
+  command: "mysql -uroot -p{{ pxc_root_password }} -e 'SELECT * FROM mysql.time_zone_name;' -B"
+  register: __pxc_check_timezone
+  no_log: yes   # pxc_root_password をログに出力させないようにするために設定
+  changed_when: no
+
+## timezone テーブルをインポートするタスク
+- name: Import timezone table from SQL query
+  shell: "mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot -p{{ pxc_root_password }} mysql"
+  no_log: yes   # pxc_root_password をログに出力させないようにするために設定
+  when: 
+    - inventory_hostname == pxc_db_control_node
+    - (__pxc_check_timezone.stdout_lines | length) == 0
+
+## タイムゾーンをインポートした証をファイルとして保存する.
+- name: Create /etc/mysql/timezone_db_is_imported.create_by_ansible.txt
+  file:
+    path: "/etc/mysql/timezone_db_is_imported.create_by_ansible.txt"
+    state: "touch"
+    owner: "root"
+    group: "root"
+    mode: "0644"

--- a/tasks/add_timezone_table.yml
+++ b/tasks/add_timezone_table.yml
@@ -4,7 +4,7 @@
 
 ## timezone テーブルがインポートされているかどうかのチェック
 - name: Check installed timezone table
-  command: "mysql -uroot -p{{ pxc_root_password }} -e 'SELECT * FROM mysql.time_zone_name;' -B"
+  command: "mysql -uroot '-p{{ pxc_root_password }}' -e 'SELECT * FROM mysql.time_zone_name;' -B"
   register: __pxc_check_timezone
   no_log: yes   # pxc_root_password をログに出力させないようにするために設定
   changed_when: no
@@ -15,7 +15,7 @@
   command: >-
     bash -c "
       set -o pipefail &&
-      mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot -p{{ pxc_root_password }} mysql
+      mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot '-p{{ pxc_root_password }}' mysql
     "
   no_log: yes   # pxc_root_password をログに出力させないようにするために設定
   when:

--- a/tasks/add_timezone_table.yml
+++ b/tasks/add_timezone_table.yml
@@ -4,7 +4,7 @@
 
 ## timezone テーブルがインポートされているかどうかのチェック
 - name: Check installed timezone table
-  command: "mysql -uroot '-p{{ pxc_root_password }}' -e 'SELECT * FROM mysql.time_zone_name;' -B"
+  command: "mysql -uroot -p{{ pxc_root_password | quote }} -e 'SELECT * FROM mysql.time_zone_name;' -B"
   register: __pxc_check_timezone
   no_log: yes   # pxc_root_password をログに出力させないようにするために設定
   changed_when: no
@@ -15,7 +15,7 @@
   command: >-
     bash -c "
       set -o pipefail &&
-      mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot '-p{{ pxc_root_password }}' mysql
+      mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot -p{{ pxc_root_password | quote }} mysql
     "
   no_log: yes   # pxc_root_password をログに出力させないようにするために設定
   when:

--- a/tasks/add_timezone_table.yml
+++ b/tasks/add_timezone_table.yml
@@ -12,9 +12,11 @@
 
 ## timezone テーブルをインポートするタスク
 - name: Import timezone table from SQL query
-  shell: >-
-    set -o pipefail &&
-    mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot -p{{ pxc_root_password }} mysql
+  command: >-
+    bash -c "
+      set -o pipefail &&
+      mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot -p{{ pxc_root_password }} mysql
+    "
   no_log: yes   # pxc_root_password をログに出力させないようにするために設定
   when:
     - inventory_hostname == pxc_db_control_node

--- a/tasks/add_timezone_table.yml
+++ b/tasks/add_timezone_table.yml
@@ -11,9 +11,11 @@
 
 ## timezone テーブルをインポートするタスク
 - name: Import timezone table from SQL query
-  shell: "mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot -p{{ pxc_root_password }} mysql"
+  shell: >-
+    set -o pipefail &&
+    mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot -p{{ pxc_root_password }} mysql
   no_log: yes   # pxc_root_password をログに出力させないようにするために設定
-  when: 
+  when:
     - inventory_hostname == pxc_db_control_node
     - (__pxc_check_timezone.stdout_lines | length) == 0
 

--- a/tasks/add_timezone_table.yml
+++ b/tasks/add_timezone_table.yml
@@ -8,6 +8,7 @@
   register: __pxc_check_timezone
   no_log: yes   # pxc_root_password をログに出力させないようにするために設定
   changed_when: no
+  check_mode: no
 
 ## timezone テーブルをインポートするタスク
 - name: Import timezone table from SQL query

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -61,7 +61,7 @@
 #    * /etc/mysql/timezone_db_is_imported.create_by_ansible.txt が存在しない.
 #    * __pxc_combined_general_settings.default_time_zone が定義されている
 #
-#  * 上記の条件についてを付ける理由について
+#  * 上記の条件を付ける理由について
 #    * timezone の設定は PXC が起動した後に実行する必要がある.
 #    * しかし, インストール直後はまだ PXC は起動していない.
 #    * さらに, my.cnf の作成は起動前に一度しておく必要がある.

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -49,6 +49,25 @@
   when:
     - __pxc_combined_general_settings['innodb_parallel_doublewrite_path'] != "xb_doublewrite"
 
+## /etc/mysql/timezone_db_is_imported.create_by_ansible.txt が存在するかどうかを確認するタスク
+#  * このファイルの有無でタイムゾーン用のテーブルをインポートしているかどうかを判断できるようになる.
+- name: Check to exist /etc/mysql/timezone_db_is_imported.create_by_ansible.txt
+  stat:
+    path: "/etc/mysql/timezone_db_is_imported.create_by_ansible.txt"
+  register: __pxc_imported_timezone_table
+
+## my.cnf を作成するタスク
+#  * 以下の条件をすべて満たす時, default_time_zone の値を null にする
+#    * /etc/mysql/timezone_db_is_imported.create_by_ansible.txt が存在しない.
+#    * __pxc_combined_general_settings.default_time_zone が定義されている
+#
+#  * 上記の条件についてを付ける理由について
+#    * timezone の設定は PXC が起動した後に実行する必要がある.
+#    * しかし, インストール直後はまだ PXC は起動していない.
+#    * さらに, my.cnf の作成は起動前に一度しておく必要がある.
+#
+#    これらの理由のため, 上記の条件にヒットする場合は一度
+#    タイムゾーン設定を無視して, PXC を起動する必要がある.
 - name: Create my.cnf
   template:
     src: my.cnf.j2
@@ -56,6 +75,19 @@
     owner: root
     group: root
     mode: "0644"
+  vars:
+    ## 少し分かりづらいのでやっていることの解説
+    #  * タイムゾーン用のテーブルがインポートされていない場合
+    #    (つまり, __pxc_imported_timezone_table.stat.exists が false の場合), 
+    #    __pxc_combined_general_settings.default_time_zone を null (Jinja2 では None) にしている.
+    __pxc_combined_general_settings: |
+      {{
+        __pxc_defaults_general_settings |
+        combine(pxc_general_settings, recursive=True) |
+        combine(
+          ( __pxc_imported_timezone_table.stat.exists) | ternary({}, { 'default_time_zone': None } ),
+          recursive=True
+        ) }}
 
 - name: Bootstrap cluster
   import_tasks: bootstrap.yml
@@ -83,6 +115,24 @@
     - localhost
   when:
     - inventory_hostname == pxc_db_control_node
+
+## MySQL のタイムゾーンを設定するためのテーブルをインポートするタスク
+- name: Add timezone table
+  import_tasks: add_timezone_table.yml
+  when:
+    - __pxc_combined_general_settings.default_time_zone is defined
+    - __pxc_combined_general_settings.default_time_zone != None
+    - not __pxc_imported_timezone_table.stat.exists
+
+## my.cnf を改めて作成するタスク
+#  * こちらは default_time_zone もちゃんと反映させる.
+- name: Re-create my.cnf
+  template:
+    src: my.cnf.j2
+    dest: "{{ pxc_mycnf_path }}"
+    owner: root
+    group: root
+    mode: "0644"
 
 ## SET GLOBAL 可能なシステム変数を適用するタスク
 #  以下のように pxc_general_settings の定義方法1と2の両方に対応するような書き方となっている

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -109,6 +109,7 @@
     login_host: "localhost"
     variable: "{{ item.value.variable | default(item.key) }}"
     value: "{{ item.value.value | default(item.value) }}"
+  when: item.value != None
   loop: "{{ __pxc_combined_general_settings | dict2items }}"
 
 - name: Create mysql users

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -40,11 +40,11 @@
   apt:
     name: "percona-xtradb-cluster-{{ pxc_version }}"
     update_cache: yes
-  register: installed
+  register: __pxc_installed
 
-- name: Stop percona (mysql) if just installed
+- name: Stop percona (mysql) if just __pxc_installed
   systemd:
     name: mysql.service
     state: stopped
   when:
-    - installed.changed
+    - __pxc_installed.changed

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -5,30 +5,38 @@
 ## clustering_settings
 {% if pxc_is_clustered | bool %}
 {%   for item in (__pxc_combined_clustering_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{{     key }} = {{ value }}
+{%     if value != None %}
+{{       key }} = {{ value }}
+{%     endif %}
 {%   endfor %}
 {% else %}
 {%   for item in (__pxc_combined_clustering_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-#{{    key }} = {{ value }}
+{%     if value != None %}
+#{{      key }} = {{ value }}
+{%     endif %}
 {%   endfor %}
 {% endif %}
 
 
 ## mycnf_settings
 {% for item in (__pxc_combined_mycnf_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{%   if value is iterable and value is not string %}
-{%     for inValue in value %}
-{{       key }} = {{ inValue }}
-{%     endfor %}
-{%   else %}
-{{       key }} = {{ value }}
+{%   if value != None %}
+{%     if value is iterable and value is not string %}
+{%       for inValue in value %}
+{{         key }} = {{ inValue }}
+{%       endfor %}
+{%     else %}
+{{         key }} = {{ value }}
+{%     endif %}
 {%   endif %}
 {% endfor %}
 
 
 ## general_settings
 {% for item in (__pxc_combined_general_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{{   key }} = {{ value.value | default(value) }}
+{%   if value != None %}
+{{     key }} = {{ value.value | default(value) }}
+{%   endif %}
 {% endfor %}
 
 

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -4,31 +4,31 @@
 [mysqld]
 ## clustering_settings
 {% if pxc_is_clustered | bool %}
-{% for item in (__pxc_combined_clustering_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{{ key }} = {{ value }}
-{% endfor %}
+{%   for item in (__pxc_combined_clustering_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
+{{     key }} = {{ value }}
+{%   endfor %}
 {% else %}
-{% for item in (__pxc_combined_clustering_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-#{{ key }} = {{ value }}
-{% endfor %}
+{%   for item in (__pxc_combined_clustering_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
+#{{    key }} = {{ value }}
+{%   endfor %}
 {% endif %}
 
 
 ## mycnf_settings
 {% for item in (__pxc_combined_mycnf_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{% if value is iterable and value is not string %}
-{% for inValue in value %}
-{{ key }} = {{ inValue }}
-{% endfor %}
-{% else %}
-{{ key }} = {{ value }}
-{% endif %}
+{%   if value is iterable and value is not string %}
+{%     for inValue in value %}
+{{       key }} = {{ inValue }}
+{%     endfor %}
+{%   else %}
+{{       key }} = {{ value }}
+{%   endif %}
 {% endfor %}
 
 
 ## general_settings
 {% for item in (__pxc_combined_general_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{{ key }} = {{ value.value | default(value) }}
+{{   key }} = {{ value.value | default(value) }}
 {% endfor %}
 
 

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -5,13 +5,13 @@
 ## clustering_settings
 {% if pxc_is_clustered | bool %}
 {%   for item in (__pxc_combined_clustering_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{%     if value != None %}
+{%     if value != None %}{# value が None (yml では null) の時は my.cnf に反映させない. #}
 {{       key }} = {{ value }}
 {%     endif %}
 {%   endfor %}
-{% else %}
+{% else %}{# スタンドアロンモードとして動かすため必要のない設定だが, コメントアウト状態で設定を残したいため一応用意することにした. #}
 {%   for item in (__pxc_combined_clustering_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{%     if value != None %}
+{%     if value != None %}{# value が None (yml では null) の時は my.cnf に反映させない. #}
 #{{      key }} = {{ value }}
 {%     endif %}
 {%   endfor %}
@@ -20,12 +20,12 @@
 
 ## mycnf_settings
 {% for item in (__pxc_combined_mycnf_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{%   if value != None %}
-{%     if value is iterable and value is not string %}
+{%   if value != None %}{# value が None (yml では null) の時は my.cnf に反映させない. #}
+{%     if value is iterable and value is not string %}{# value がリストの時. 例: ignore-db-dir 等は key と value が1対多の関係なのでこの if 文が必要. #}
 {%       for inValue in value %}
 {{         key }} = {{ inValue }}
 {%       endfor %}
-{%     else %}
+{%     else %}{# value がリストでない時. #}
 {{         key }} = {{ value }}
 {%     endif %}
 {%   endif %}
@@ -34,7 +34,8 @@
 
 ## general_settings
 {% for item in (__pxc_combined_general_settings | dictsort(by='key')) %}{% set key = item[0] %}{% set value = item[1] %}
-{%   if value != None %}
+{%   if value != None %}{# value が None (yml では null) の時は my.cnf に反映させない. #}
+{#     ↓ の書き方をすることについて, 詳しい説明は tasks/configure.yml の 「Update mysql pxc_general_settings (not required to restart)」 タスクを参照 #}
 {{     key }} = {{ value.value | default(value) }}
 {%   endif %}
 {% endfor %}


### PR DESCRIPTION
@ledyba-z 
タイムゾーンの設定をするための処理が意外と煩雑だったので確認していただければと思います.

## 変更点
#3 だけではタイムゾーンの設定をするには不十分なため, このような変更を追加
* my.cnf を作成する際に一部の変数を無効化するための機能を追加 (https://github.com/link-u/ansible-roles-v2_percona-cluster/commit/a4b24c477d96596df55b9ea58d5dcdd2c517c205).
* タイムゾーンを設定するためのテーブルをインポートするタスクを追加

## 参考
* https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html