### PR TITLE
ansible-ci-module と github actions の workflow の更新

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Create tox env list
         id: set-matrix
         run: |
-          TOX_ENV=$(python3 ansible-ci-module/scripts/toxenv_to_json.py)
-          echo "::set-output name=matrix::{\"tox_env\":[${TOX_ENV}]}"
+          MATRIX=$(python3 ansible-ci-module/scripts/matrix.py)
+          echo "::set-output name=matrix::${MATRIX}"
 
   ansible-ci:
     needs: create-matrix
@@ -58,7 +58,7 @@ jobs:
       - name: ansible-ci
         run: |
           if [ -f ./tox.ini ]; then
-            sudo tox -e ${{ matrix.tox_env }} -c tox.ini
+            sudo MOLECULE_SCENARIO=${{ matrix.scenario }} tox -e ${{ matrix.tox_env }} -c tox.ini
           else
-            sudo tox -e ${{ matrix.tox_env }} -c ansible-ci-module/tox.ini
+            sudo MOLECULE_SCENARIO=${{ matrix.scenario }} tox -e ${{ matrix.tox_env }} -c ansible-ci-module/tox.ini
           fi

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -4,16 +4,25 @@ platforms:
     source:
       alias: ubuntu/${MOLECULE_DISTRO}/amd64
     lxc_limit_memory: "2GB"
+    host_vars:
+      local_ipv4: "172.29.95.31"
+      local_ipv4_prefix: "24"
 
   - name: ${MOLECULE_DISTRO}-${ANSIBLE_VER}-b
     source:
       alias: ubuntu/${MOLECULE_DISTRO}/amd64
     lxc_limit_memory: "2GB"
+    host_vars:
+      local_ipv4: "172.29.95.32"
+      local_ipv4_prefix: "24"
 
   - name: ${MOLECULE_DISTRO}-${ANSIBLE_VER}-c
     source:
       alias: ubuntu/${MOLECULE_DISTRO}/amd64
     lxc_limit_memory: "2GB"
+    host_vars:
+      local_ipv4: "172.29.95.33"
+      local_ipv4_prefix: "24"
 
 lxd_commands: |
   lxc network set lxdbr0 ipv6.address none


### PR DESCRIPTION
### 変更点
* github actions のマトリックスジョブの拡張.
* cluster シナリオにおいて, host_vars に local_ipv4 の設定を追加.
  * a系
    https://github.com/link-u/ansible-roles-v2_percona-cluster/blob/cf1189f3df42d2140a465df603d45fec006c2f8e/molecule/cluster/molecule.yml#L7-L9

  * b系
https://github.com/link-u/ansible-roles-v2_percona-cluster/blob/cf1189f3df42d2140a465df603d45fec006c2f8e/molecule/cluster/molecule.yml#L15-L17

  * c系
https://github.com/link-u/ansible-roles-v2_percona-cluster/blob/cf1189f3df42d2140a465df603d45fec006c2f8e/molecule/cluster/molecule.yml#L23-L25
