### PR TITLE
binlogのディレクトリチェックバグ修正

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,7 +15,7 @@
 
 - name: Ensure log-bin directories are present with proper owner
   file:
-    path: "{{ __pxc_combined_mycnf_settings['log-bin'] }}"
+    path: "{{ __pxc_combined_mycnf_settings['log-bin'] | dirname }}"
     state: directory
     owner: mysql
     group: mysql


### PR DESCRIPTION
`my.cnf` の `log-bin` に設定されるのはディレクトリ名ではなくファイル名のプレフィックスなので、
ディレクトリ名を抽出して存在チェックするようにしました。