### PR TITLE
回避策だが /var/lib/mysqld のパーミッションは指定しない (べき等性の担保ができない)

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -19,7 +19,6 @@
     state: directory
     owner: mysql
     group: mysql
-    mode: "0750"
 
 - name: "Check for existing {{ __pxc_combined_clustering_settings['wsrep_data_home_dir'] }}/grastate.dat"
   stat:


### PR DESCRIPTION
### CI に失敗していた原因
`"{{ __pxc_combined_mycnf_settings['log-bin'] | dirname }}"` デフォルト値である
 `/var/lib/mysql` のパーミッションを指定していたが, その後の mysqld の起動によって改めてパーミッションが変わってしまった.

そのため, 2度目の ansible の流し込みチェックで changed が発生してしまい, 冪等性チェックに失敗してしまっていた.

### 回避策

mysqld の起動によって決まるパーミッションで問題ないので, ansible で明示的に指定する必要はないという判断
